### PR TITLE
fix Input props caching

### DIFF
--- a/lua/fine-cmdline/init.lua
+++ b/lua/fine-cmdline/init.lua
@@ -40,27 +40,14 @@ local defaults = {
   }
 }
 
-local popup_options = {}
-
 M.input = nil
-
 M.setup = function(config)
   config = config or {}
   state.user_opts = config
 
-  popup_options = fn.merge(defaults.popup, config.popup)
-
+  local popup_options = fn.merge(defaults.popup, config.popup)
   state.hooks = fn.merge(defaults.hooks, config.hooks)
   state.cmdline = fn.merge(defaults.cmdline, config.cmdline)
-
-end
-
-M.open = function()
-  if not M.input or not vim.api.nvim_buf_is_valid(M.input.bufnr) then
-    M.setup(state.user_opts)
-  end
-
-  state.hooks.before_mount(M.input)
 
   M.input = Input(popup_options, {
     prompt = ': ',
@@ -74,6 +61,11 @@ M.open = function()
       fn.reset_history()
     end,
   })
+end
+
+M.open = function()
+  M.setup(state.user_opts)
+  state.hooks.before_mount(M.input)
 
   M.input:mount()
 
@@ -199,4 +191,3 @@ fn.feedkeys = function(keys)
 end
 
 return M
-

--- a/lua/fine-cmdline/init.lua
+++ b/lua/fine-cmdline/init.lua
@@ -40,14 +40,27 @@ local defaults = {
   }
 }
 
+local popup_options = {}
+
 M.input = nil
+
 M.setup = function(config)
   config = config or {}
   state.user_opts = config
 
-  local popup_options = fn.merge(defaults.popup, config.popup)
+  popup_options = fn.merge(defaults.popup, config.popup)
+
   state.hooks = fn.merge(defaults.hooks, config.hooks)
   state.cmdline = fn.merge(defaults.cmdline, config.cmdline)
+
+end
+
+M.open = function()
+  if not M.input or not vim.api.nvim_buf_is_valid(M.input.bufnr) then
+    M.setup(state.user_opts)
+  end
+
+  state.hooks.before_mount(M.input)
 
   M.input = Input(popup_options, {
     prompt = ': ',
@@ -61,14 +74,6 @@ M.setup = function(config)
       fn.reset_history()
     end,
   })
-end
-
-M.open = function()
-  if not M.input or not vim.api.nvim_buf_is_valid(M.input.bufnr) then
-    M.setup(state.user_opts)
-  end
-
-  state.hooks.before_mount(M.input)
 
   M.input:mount()
 


### PR DESCRIPTION
Hello, thank you for plugin!

I found an issue, which is when you calling `setup` it remembers `M.Input` object with all required calculations, and if screen size changed ( for me it was tmux splits ), popup config passed by user is not relevant anymore:

https://user-images.githubusercontent.com/21224705/142933682-c10fc841-df27-4013-9ea9-066f3d8471e8.mp4

so I just moved initialization of `M.Input` to `open` call to do it every time before rendering...

here is my config chunk:
```
            require("fine-cmdline").setup(
                {
                    popup = {
                        relative = "win",
                        position = {
                            row = "50%",
                            col = "50%"
                        },
                        size = {
                            width = "60%",
                            height = 1
                        }
                    }
                }
            )
```
