### PR TITLE
Set documentation ft to help

### DIFF
--- a/doc/fine-cmdline.txt
+++ b/doc/fine-cmdline.txt
@@ -342,3 +342,4 @@ Support                                                *fine-cmdline-donation*
 If you find this tool useful and want to support my efforts, consider
 leaving a tip in https://www.buymeacoffee.com/vonheikemen
 
+vim:tw=78:sw=4:ft=help:norl:


### PR DESCRIPTION
The `filetype` of the help page is `text` instead of `help`. 

I tested with `nvim --clean`. I guess it's missing the standard last line `vim:tw=78:sw=4:ft=help:norl:`. 

So here a fix if you want.